### PR TITLE
feat: Container 컴포넌트 안에 Board 정렬 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ dependencies:
     version: 18.3.1(react@18.3.1)
 
 devDependencies:
+  '@chakra-ui/icons':
+    specifier: ^2.1.1
+    version: 2.1.1(@chakra-ui/system@2.6.2)(react@18.3.1)
   '@chakra-ui/react':
     specifier: ^2.8.2
     version: 2.8.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(framer-motion@11.2.12)(react-dom@18.3.1)(react@18.3.1)
@@ -619,6 +622,17 @@ packages:
       react: '>=18'
     dependencies:
       '@chakra-ui/shared-utils': 2.0.5
+      '@chakra-ui/system': 2.6.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.3.1)
+      react: 18.3.1
+    dev: true
+
+  /@chakra-ui/icons@2.1.1(@chakra-ui/system@2.6.2)(react@18.3.1):
+    resolution: {integrity: sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=2.0.0'
+      react: '>=18'
+    dependencies:
+      '@chakra-ui/icon': 3.2.0(@chakra-ui/system@2.6.2)(react@18.3.1)
       '@chakra-ui/system': 2.6.2(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.3.1)
       react: 18.3.1
     dev: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import './App.css';
 import Test from './Test';
+import BoardContainer from './components/boardContainer/BoardContainer';
 import Header from './components/header/Header';
 
 function App() {
   return (
     <ChakraProvider>
       <Header />
+      <BoardContainer />
       <Test />
     </ChakraProvider>
   );

--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -1,5 +1,25 @@
-const Board = () => {
-  return <div>Board</div>;
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import { Card, CardHeader, Heading, List, ListIcon, ListItem } from '@chakra-ui/react';
+
+const Board = (props: { title: string }) => {
+  const itemArr = ['item1', '아이템2', 'item3', 'item4', 'item', 'item', 'item', 'item', 'item'];
+  return (
+    <Card borderRadius='8px' bg='#dddddd'>
+      <CardHeader>
+        <Heading size='xm' textAlign='center'>
+          {props.title}
+        </Heading>
+      </CardHeader>
+      <List>
+        {itemArr.map((item, idx) => (
+          <ListItem key={idx}>
+            <ListIcon as={InfoOutlineIcon} />
+            {item}
+          </ListItem>
+        ))}
+      </List>
+    </Card>
+  );
 };
 
 export default Board;

--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -1,25 +1,33 @@
-import { InfoOutlineIcon } from '@chakra-ui/icons';
-import { Card, CardHeader, Heading, List, ListIcon, ListItem } from '@chakra-ui/react';
+import { Card, CardHeader, Heading, List } from '@chakra-ui/react';
+import styled from 'styled-components';
+import Item from '../item/Item';
 
 const Board = (props: { title: string }) => {
   const itemArr = ['item1', '아이템2', 'item3', 'item4', 'item', 'item', 'item', 'item', 'item'];
   return (
     <Card borderRadius='8px' bg='#dddddd'>
-      <CardHeader>
+      <StyledCardHeader>
         <Heading size='xm' textAlign='center'>
           {props.title}
         </Heading>
-      </CardHeader>
-      <List>
+      </StyledCardHeader>
+      <StyledList>
         {itemArr.map((item, idx) => (
-          <ListItem key={idx}>
-            <ListIcon as={InfoOutlineIcon} />
-            {item}
-          </ListItem>
+          <Item item={item} key={idx} />
         ))}
-      </List>
+      </StyledList>
     </Card>
   );
 };
 
 export default Board;
+
+const StyledCardHeader = styled(CardHeader)`
+  &&& {
+    padding: 0.5rem;
+  }
+`;
+
+const StyledList = styled(List)`
+  margin-bottom: 0.5rem;
+`;

--- a/src/components/boardContainer/BoardContainer.tsx
+++ b/src/components/boardContainer/BoardContainer.tsx
@@ -1,5 +1,51 @@
+import { Container, SimpleGrid } from '@chakra-ui/react';
+import styled from 'styled-components';
+import Board from '../board/Board';
+
 const BoardContainer = () => {
-  return <div>BoardContainer</div>;
+  const arr = [
+    'title1',
+    'title12',
+    'title13',
+    'title14',
+    'title15',
+    'title16',
+    'title17',
+    'title18',
+    'title19',
+    'title10',
+    'title11',
+    'title12',
+    'title13',
+    'title14',
+  ];
+  return (
+    <StyledContainer bg='white'>
+      <StyledSimpleGrid columns={{ base: 2, md: 3, lg: 3 }} spacing={3}>
+        {arr.map((v, idx) => (
+          <Board title={v} key={idx} />
+        ))}
+      </StyledSimpleGrid>
+    </StyledContainer>
+  );
 };
 
 export default BoardContainer;
+
+const StyledContainer = styled(Container)`
+  padding: 0.8rem !important;
+  margin-top: 2vh;
+  height: max-content;
+  max-width: 90vw !important;
+  min-width: 40rem;
+  border-radius: 1rem;
+  box-shadow: rgba(67, 71, 85, 0.27) 0px 0px 0.25em, rgba(90, 125, 188, 0.05) 0px 0.25em 1em;
+  display: flex;
+  justify-content: space-around;
+`;
+
+const StyledSimpleGrid = styled(SimpleGrid)`
+  padding: 0;
+  margin: 0;
+  width: 100%; /* 추가된 부분 */
+`;

--- a/src/components/boardContainer/boardContainer.tsx
+++ b/src/components/boardContainer/boardContainer.tsx
@@ -1,5 +1,0 @@
-const boardContainer = () => {
-  return <div>boardContainer</div>;
-};
-
-export default boardContainer;

--- a/src/components/item/Item.tsx
+++ b/src/components/item/Item.tsx
@@ -1,5 +1,44 @@
-const Item = () => {
-  return <div>Item</div>;
+import { EditIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { Box, Button, ListIcon, ListItem } from '@chakra-ui/react';
+import styled from 'styled-components';
+
+const Item = (props: { item: string }) => {
+  return (
+    <StyledListItem>
+      <StyledBox>
+        <ListIcon as={InfoOutlineIcon} />
+        {props.item}
+      </StyledBox>
+      <StyledBox>
+        <StyledButton as={EditIcon}>...</StyledButton>
+      </StyledBox>
+    </StyledListItem>
+  );
 };
 
 export default Item;
+
+const StyledListItem = styled(ListItem)`
+  &&& {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-inline: 0.5rem;
+    width: 100%;
+  }
+`;
+
+const StyledBox = styled(Box)`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledButton = styled(Button)`
+  &&& {
+    height: max-content;
+    margin: 0;
+  }
+  :hover {
+    color: red;
+  }
+`;


### PR DESCRIPTION
<img width="1280" alt="스크린샷 2024-07-02 오후 10 44 09" src="https://github.com/lgyn10/mark-tab/assets/72643542/76157622-5990-4bc2-97e6-8f066f1b2089">
- 넓이에 따라 Board의 개수를 최소 2개에서 최대 3개로 동적 조정
