### PR TITLE
fix: 타입 선언 관련

### DIFF
--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -10,7 +10,7 @@ type TBoardProps = {
 
 const Board = ({ boardTitle, boardId }: TBoardProps) => {
   const { bookmarkNode } = bookmarkStore();
-  const board = bookmarkNode?.children!.find((node) => node.id === boardId)?.children!;
+  const items = bookmarkNode?.children!.find((node) => node.id === boardId)?.children;
   return (
     <StyledCard>
       <StyledCardHeader>
@@ -19,9 +19,8 @@ const Board = ({ boardTitle, boardId }: TBoardProps) => {
         </Heading>
       </StyledCardHeader>
       <StyledList>
-        {board.map((node) => (
-          <Item key={node.id} itemTitle={node.title} itemUrl={node.url!} itemId={node.id} />
-        ))}
+        {items &&
+          items.map((node) => <Item key={node.id} itemTitle={node.title} itemUrl={node.url!} itemId={node.id} />)}
       </StyledList>
     </StyledCard>
   );

--- a/src/components/boardContainer/BoardContainer.tsx
+++ b/src/components/boardContainer/BoardContainer.tsx
@@ -7,11 +7,13 @@ import Board from '../board/Board';
 
 const BoardContainer = () => {
   const { bookmarkNode, fetchBookmarkTreeNode } = bookmarkStore();
+  const boards = bookmarkNode?.children;
 
   useEffect(() => {
     fetchBookmarkTreeNode();
     console.log('fetchBookmarkTreeNode activated');
   }, []);
+
   useEffect(() => {
     console.log('rerendering');
   }, [bookmarkNode]);
@@ -27,9 +29,7 @@ const BoardContainer = () => {
         columnSize={0}
         columnSizeRatio={0}
       >
-        {bookmarkNode?.children!.map(({ id, title }) => (
-          <Board boardTitle={title} boardId={id} key={id} />
-        ))}
+        {boards && boards.map(({ id, title }) => <Board boardTitle={title} boardId={id} key={id} />)}
       </StyledMasonryGrid>
     </StyledContainer>
   );


### PR DESCRIPTION
@yoonhb173 

코드 구현은 bookmarkNode 배열에서 항상 children이 존재함을 가정했습니다. 
타입 정의할 때는 옵셔널 프로퍼티(?:)를 children에 사용했는데, 이는 `@types/chrome` 패키지가 타입을 확인해서 옵셔널 프로퍼티를 주지 않으면 타입 에러를 내서 ?:를 붙였습니다..!

<img width="818" alt="스크린샷 2024-07-08 오후 4 13 32" src="https://github.com/lgyn10/mark-tab/assets/72643542/b1ff0f6c-3529-4f93-a81f-2332707847d2">

그래서 타입 정의와 실제 구현하는 코드가 상반되게 보일 것 같습니다!

그리고 
> bookmarkNode?.children && bookmarkNode?.children.map
또는 해당 옵셔널 체이닝을 제거 해주셔야 타입 선언에 맞는 코드가 될 것 같습니다!

이 부분은 살짝 이해하기 어렵습니다..! 

피드백을 적용해서 먼저 boards && boards.map 와 같은 형식으로 수정은 해보았는데, 의도하신 방향인지 잘 모르겠습니다..

non null assertion operator를 사용하지 않는 쪽으로 의도하시는 것 같기도 하구요..

혹시 이 부분에 시간 괜찮으실 때 허들로 이야기 나눌 수 있으실까요..?